### PR TITLE
Add link to production website to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ipquest
-It's Dangerous To Go Alone.
+[It's Dangerous To Go Alone.](http://patentquest.mozilla.org/)
+
+Patents are [challenging for open-source software][blog]. But that doesn't mean they
+aren't challenging for others, too! Thankfully, the heroes from our most
+beloved RPGs and stories never had to deal with patents. But what if they did?
+
+[blog]: https://blog.mozilla.org/netpolicy/2015/04/15/open-source-software-and-the-patent-system/


### PR DESCRIPTION
I found the GitHub repo and had to search to find the website. It would be nice if it was linked from the README. Also add blurb from the beginning of the game.

Great job, I hope you keep expanding the adventure!
